### PR TITLE
fix: Make fetch work from a static html file

### DIFF
--- a/tasks/task_list/templates/task_list/task-list.html
+++ b/tasks/task_list/templates/task_list/task-list.html
@@ -12,7 +12,7 @@
 	<h1>Big Ass List of Tasks</h1>
 	{{result}}
 	<script>
-		const request = new Request("http://127.0.0.1:8080/task_list/", { headers: { "Access-Control-Allow-Origin": "*" },"mode":"cors"})
+		const request = new Request("http://127.0.0.1:8000/task_list/", { headers: { "Access-Control-Allow-Origin": "*" },"mode":"no-cors"})
 		fetch(request)
 		.then((response)=>{
 			console.log(response)


### PR DESCRIPTION
This change includes a fix to make fetch work loading from the correct api port (8000) + setting fetch mode to `no-cors`

In case you wanted to keep playing with this route. This obviously wont work forever since you can't pass certain important headers with `no-cors` enabled.

see details about [mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) and [this blog](https://medium.com/@cybersphere/fetch-api-the-ultimate-guide-to-cors-and-no-cors-cbcef88d371e)

![](https://miro.medium.com/v2/resize:fit:1056/format:webp/1*ZjTdRh8yPeder-h84IsxcQ.jpeg)

Keep up the learning!